### PR TITLE
Remove unused dataset setup in attention figure script

### DIFF
--- a/src/paper/generate_attention_figure.py
+++ b/src/paper/generate_attention_figure.py
@@ -79,7 +79,6 @@ def generate_attention_figure(cfg_dict):
         step_tracker=None,
     )
     model_wrapper.eval()
-    dataset = iter(get_dataset(cfg.dataset, "test", None))
 
     # Create a dataset that always returns the desired scene.
     view_sampler_cfg = ViewSamplerArbitraryCfg(


### PR DESCRIPTION
## Summary

The attention figure script initialized the test dataset once, then immediately set up a different dataset path for the desired scene. The first initialization looked unused and made the setup more confusing.

This PR removes that earlier unused dataset initialization so the figure script only uses the dataset created for the selected scene.

## Verification

- The original PR did not record a test command.